### PR TITLE
Bump garden-cli to 0.12.54.

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,9 +1,9 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.12.53/garden-0.12.53-macos-amd64.tar.gz"
-  version "0.12.53"
-  sha256 "1f0a84403b988df2acd03492589fa1a7b5241e1557e44f9eed239f5e685bc2d9"
+  url "https://download.garden.io/core/0.12.54/garden-0.12.54-macos-amd64.tar.gz"
+  version "0.12.54"
+  sha256 "7008da1051a2d7edd531a18dc56d8f08941754ced7c3bde736ee09a40f22b36e"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@Walther Please review this PR carefully and merge once Garden 0.12.54 should be released to Homebrew.