### PR TITLE
Bump garden-cli to 0.12.57.

### DIFF
--- a/Formula/garden-cli@0.12.rb
+++ b/Formula/garden-cli@0.12.rb
@@ -1,9 +1,9 @@
 class GardenCliAT012 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.12.56/garden-0.12.56-macos-amd64.tar.gz"
-  version "0.12.56"
-  sha256 "20104836cac2b300bb1b1055fce019af7d9468132c9cb074d3d196fe69c706fe"
+  url "https://download.garden.io/core/0.12.57/garden-0.12.57-macos-amd64.tar.gz"
+  version "0.12.57"
+  sha256 "e4600a1b5de070b4e8619e7f9ee7fa4e831d9155e844ecac5b08a9a9b540ccd4"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@Orzelius Please review this PR carefully and merge once Garden 0.12.57 should be released to Homebrew.