### PR TITLE
Bump garden-cli to 0.13.2.

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,9 +1,9 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.13.1/garden-0.13.1-macos-amd64.tar.gz"
-  version "0.13.1"
-  sha256 "423c67a3d6338b4cec363320b8a32aeb1d976c9c9fb4875ac34564b81104636e"
+  url "https://download.garden.io/core/0.13.2/garden-0.13.2-macos-amd64.tar.gz"
+  version "0.13.2"
+  sha256 "63bf03d36def5dd94bae94037de4aa799d3374cedd5a436ceb4223d7ce2d9598"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.13.2 should be released to Homebrew.