### PR TITLE
Bump garden-cli to 0.13.8.

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,9 +1,9 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.13.7/garden-0.13.7-macos-amd64.tar.gz"
-  version "0.13.7"
-  sha256 "c51e5ceb487ffee9a43f73b08d0d8abfefca7cedcff959b9413204d433ae2ba7"
+  url "https://download.garden.io/core/0.13.8/garden-0.13.8-macos-amd64.tar.gz"
+  version "0.13.8"
+  sha256 "41fea16ef9c38c8c4e48ad7a6191537be6c0714eb7a0871ef7a10558ea03e5e3"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.13.8 should be released to Homebrew.