### PR TITLE
Bump garden-cli to 0.12.63.

### DIFF
--- a/Formula/garden-cli@0.12.rb
+++ b/Formula/garden-cli@0.12.rb
@@ -1,9 +1,9 @@
 class GardenCliAT012 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.12.62/garden-0.12.62-macos-amd64.tar.gz"
-  version "0.12.62"
-  sha256 "4f7b58058726b9863c3046dad49ed1196703e194e99460a9e7722323e689eead"
+  url "https://download.garden.io/core/0.12.63/garden-0.12.63-macos-amd64.tar.gz"
+  version "0.12.63"
+  sha256 "324ad765f3481d2a5613abbef9503315938271d6917da6df58ac0d5a4d29f811"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.12.63 should be released to Homebrew.