### PR TITLE
Bump garden-cli to 0.13.9.

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,9 +1,9 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.13.8/garden-0.13.8-macos-amd64.tar.gz"
-  version "0.13.8"
-  sha256 "41fea16ef9c38c8c4e48ad7a6191537be6c0714eb7a0871ef7a10558ea03e5e3"
+  url "https://download.garden.io/core/0.13.9/garden-0.13.9-macos-amd64.tar.gz"
+  version "0.13.9"
+  sha256 "c96ddd26aece12c35fbf34984ad50c81cdd50fde5d6f5ad0e6b868f1ac3f8d48"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.13.9 should be released to Homebrew.