### PR TITLE
Bump garden-cli to 0.13.13.

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,9 +1,9 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.13.12/garden-0.13.12-macos-amd64.tar.gz"
-  version "0.13.12"
-  sha256 "fb3a07907d4489b5c823ac9c2db142359274bea1211937fd020c0101e18fafa5"
+  url "https://download.garden.io/core/0.13.13/garden-0.13.13-macos-amd64.tar.gz"
+  version "0.13.13"
+  sha256 "45e7d55a1657b9d4af43c8a508fdfb0e1c48379829586446dba243a515fa434c"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@shumailxyz Please review this PR carefully and merge once Garden 0.13.13 should be released to Homebrew.