### PR TITLE
Bump garden-cli to 0.13.13

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -1,11 +1,19 @@
 class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.13.13/garden-0.13.13-macos-amd64.tar.gz"
+
   version "0.13.13"
-  sha256 "45e7d55a1657b9d4af43c8a508fdfb0e1c48379829586446dba243a515fa434c"
 
   depends_on "rsync"
+
+  # Determine architecture
+  if Hardware::CPU.arm?
+    url "https://download.garden.io/core/0.13.13/garden-0.13.13-macos-arm64.tar.gz"
+    sha256 "d415fd275e16ef87fe762d433c9551cff3b99d0605215975b27a583e5dee6829"
+  else
+    url "https://download.garden.io/core/0.13.13/garden-0.13.13-macos-amd64.tar.gz"
+    sha256 "45e7d55a1657b9d4af43c8a508fdfb0e1c48379829586446dba243a515fa434c"
+  end
 
   def install
     libexec.install "garden", "fsevents.node", "static"


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.13

This PR has been generated by the "Manually release Garden to Homebrew" workflow.

@stefreak Please review this PR carefully and merge once Garden {{version}} should be released to Homebrew.