### PR TITLE
Bump garden-cli to 0.13.16

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.15"
+  version "0.13.16"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.15/garden-0.13.15-macos-arm64.tar.gz"
-    sha256 "6f7498de9d4c639df17c8f2d80e290eddf29fb07a166ef44eb32e285a8e16498"
+    url "https://download.garden.io/core/0.13.16/garden-0.13.16-macos-arm64.tar.gz"
+    sha256 "50b39d5a9caa77c0ad1039e4d0c7a4ae8433030230e17c385d10c0c0be6725b9"
   else
-    url "https://download.garden.io/core/0.13.15/garden-0.13.15-macos-amd64.tar.gz"
-    sha256 "078ae03edc8e35400310e8636f77eeaa619883a07e1328eb3b74b8233c0cfca1"
+    url "https://download.garden.io/core/0.13.16/garden-0.13.16-macos-amd64.tar.gz"
+    sha256 "b7d17ce2c46f9dd3dadec268d8931f88127124568e0524588c64e640234de3e2"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.16

This PR has been generated by the publish-release workflow after the new release

@shumailxyz Please review this PR carefully and merge once Garden should be released to Homebrew.