### PR TITLE
Bump garden-cli to 0.12.65.

### DIFF
--- a/Formula/garden-cli@0.12.rb
+++ b/Formula/garden-cli@0.12.rb
@@ -1,9 +1,9 @@
 class GardenCliAT012 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.12.64/garden-0.12.64-macos-amd64.tar.gz"
-  version "0.12.64"
-  sha256 "46daa1660e13f7aa1329aa2ae3ce0ba4912e3f9982af6ce5900c99358dc0b282"
+  url "https://download.garden.io/core/0.12.65/garden-0.12.65-macos-amd64.tar.gz"
+  version "0.12.65"
+  sha256 "e8e56e2706d71fc238234b50de9afd554fffa77e372bb72bab54495c8982eddf"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.12.65 should be released to Homebrew.