### PR TITLE
Bump garden-cli to 0.13.17

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.16"
+  version "0.13.17"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.16/garden-0.13.16-macos-arm64.tar.gz"
-    sha256 "50b39d5a9caa77c0ad1039e4d0c7a4ae8433030230e17c385d10c0c0be6725b9"
+    url "https://download.garden.io/core/0.13.17/garden-0.13.17-macos-arm64.tar.gz"
+    sha256 "f506700d56b5613c7f24356347a5ba7d0d3d5e6d8e67f281a499d08520eabf7f"
   else
-    url "https://download.garden.io/core/0.13.16/garden-0.13.16-macos-amd64.tar.gz"
-    sha256 "b7d17ce2c46f9dd3dadec268d8931f88127124568e0524588c64e640234de3e2"
+    url "https://download.garden.io/core/0.13.17/garden-0.13.17-macos-amd64.tar.gz"
+    sha256 "58b12aec6ce83e77f50e262f5d56abe7d99ef8792d45430fc55813c3c58dd158"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.17

This PR has been generated by the "Manually release Garden to Homebrew" workflow.

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.