### PR TITLE
Bump garden-cli to 0.13.19

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.18"
+  version "0.13.19"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.18/garden-0.13.18-macos-arm64.tar.gz"
-    sha256 "43ff839562a621c5b91baeb3c471ce528632319db743c5cad300fea194b09acf"
+    url "https://download.garden.io/core/0.13.19/garden-0.13.19-macos-arm64.tar.gz"
+    sha256 "d7b1ce37f6b1c4ed8f706f3c408fc192b79462e4b415812e3afba37f2f1d6d0a"
   else
-    url "https://download.garden.io/core/0.13.18/garden-0.13.18-macos-amd64.tar.gz"
-    sha256 "7f2f1adf2c0d9167dbf2bf316cd232225b6fdeacf36fb4556caedf9b4af8da7c"
+    url "https://download.garden.io/core/0.13.19/garden-0.13.19-macos-amd64.tar.gz"
+    sha256 "c68bf8b600694005cd188f45dcc445d4e65807fc1a479bb150a6a6ed1b9e3e23"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.19

This PR has been generated by the publish-release workflow after the new release

@stefreak Please review this PR carefully and merge once Garden should be released to Homebrew.