### PR TITLE
Bump garden-cli to 0.13.20

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,19 +2,19 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.19"
+  version "0.13.20"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.19/garden-0.13.19-macos-arm64.tar.gz"
-    sha256 "d7b1ce37f6b1c4ed8f706f3c408fc192b79462e4b415812e3afba37f2f1d6d0a"
+    url "https://download.garden.io/core/0.13.20/garden-0.13.20-macos-arm64.tar.gz"
+    sha256 "8f17059c69c06d72959e6a214921a2a7a2e5a22fad4663e29f43e794cbe7c472"
   else
-    url "https://download.garden.io/core/0.13.19/garden-0.13.19-macos-amd64.tar.gz"
-    sha256 "c68bf8b600694005cd188f45dcc445d4e65807fc1a479bb150a6a6ed1b9e3e23"
+    url "https://download.garden.io/core/0.13.20/garden-0.13.20-macos-amd64.tar.gz"
+    sha256 "458dfb91313822fe3853afcb69f093225a0ba35b09655da44fc54eefa00e3179"
   end
 
   def install
-    libexec.install "garden", "fsevents.node", "static"
+    libexec.install "garden"
     bin.install_symlink libexec/"garden"
   end
 


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.20

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.