### PR TITLE
Bump garden-cli to 0.13.21

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.20"
+  version "0.13.21"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.20/garden-0.13.20-macos-arm64.tar.gz"
-    sha256 "8f17059c69c06d72959e6a214921a2a7a2e5a22fad4663e29f43e794cbe7c472"
+    url "https://download.garden.io/core/0.13.21/garden-0.13.21-macos-arm64.tar.gz"
+    sha256 "f1bb844402db60af1360b7d471f9864ebae81ddaf01457c4b7b21388d7f8a59b"
   else
-    url "https://download.garden.io/core/0.13.20/garden-0.13.20-macos-amd64.tar.gz"
-    sha256 "458dfb91313822fe3853afcb69f093225a0ba35b09655da44fc54eefa00e3179"
+    url "https://download.garden.io/core/0.13.21/garden-0.13.21-macos-amd64.tar.gz"
+    sha256 "d23e9456968603489e62f6f56825f858caa5108bdc431c1f3fd270c2e20f3478"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.21

This PR has been generated by the publish-release workflow after the new release

@TimBeyer Please review this PR carefully and merge once Garden should be released to Homebrew.