### PR TITLE
Bump garden-cli to 0.13.22

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.21"
+  version "0.13.22"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.21/garden-0.13.21-macos-arm64.tar.gz"
-    sha256 "f1bb844402db60af1360b7d471f9864ebae81ddaf01457c4b7b21388d7f8a59b"
+    url "https://download.garden.io/core/0.13.22/garden-0.13.22-macos-arm64.tar.gz"
+    sha256 "5b350b1d4ae25fb8d9b5b5a184f14b06dc8c5d50105a4a4c851f04d2012c8cad"
   else
-    url "https://download.garden.io/core/0.13.21/garden-0.13.21-macos-amd64.tar.gz"
-    sha256 "d23e9456968603489e62f6f56825f858caa5108bdc431c1f3fd270c2e20f3478"
+    url "https://download.garden.io/core/0.13.22/garden-0.13.22-macos-amd64.tar.gz"
+    sha256 "2a6442195920088358501ae72b5c2c248f4818445bd1699141668bae8cbe0d6e"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.22

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.