### PR TITLE
Bump garden-cli to 0.13.23

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.22"
+  version "0.13.23"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.22/garden-0.13.22-macos-arm64.tar.gz"
-    sha256 "5b350b1d4ae25fb8d9b5b5a184f14b06dc8c5d50105a4a4c851f04d2012c8cad"
+    url "https://download.garden.io/core/0.13.23/garden-0.13.23-macos-arm64.tar.gz"
+    sha256 "a934d75b5070ce267ceab5468e36b2aee995cc9b4bdd8a13501ea90a61fba399"
   else
-    url "https://download.garden.io/core/0.13.22/garden-0.13.22-macos-amd64.tar.gz"
-    sha256 "2a6442195920088358501ae72b5c2c248f4818445bd1699141668bae8cbe0d6e"
+    url "https://download.garden.io/core/0.13.23/garden-0.13.23-macos-amd64.tar.gz"
+    sha256 "f423fb292f69b6f93525709d5b19623f9198b40a86ca5d4b317a8d8bfc04a85d"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.23

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.