### PR TITLE
Bump garden-cli to 0.13.26

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.25"
+  version "0.13.26"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.25/garden-0.13.25-macos-arm64.tar.gz"
-    sha256 "396231fd65509b966207407f92c11344300b0987d7f4f8a7364b015449537dbc"
+    url "https://download.garden.io/core/0.13.26/garden-0.13.26-macos-arm64.tar.gz"
+    sha256 "0d131d52896d63a55ee8406e39465ec1f69201243e3a66a69d04e4d4a227d09e"
   else
-    url "https://download.garden.io/core/0.13.25/garden-0.13.25-macos-amd64.tar.gz"
-    sha256 "d584f490264762cccd7ef2b8209ee91fc85d59089afa71f93ad249f3c88c1033"
+    url "https://download.garden.io/core/0.13.26/garden-0.13.26-macos-amd64.tar.gz"
+    sha256 "08640eac604d25bd84b6a2d3892c910bb40e17e1daf5d5bc278a4a523fd1e95a"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.26

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.