### PR TITLE
Bump garden-cli to 0.13.28

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.27"
+  version "0.13.28"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.27/garden-0.13.27-macos-arm64.tar.gz"
-    sha256 "a1654e50ffd46a3b22b7b40f7610ac1ba550415e6c9c5717bbdf5a1f017a0107"
+    url "https://download.garden.io/core/0.13.28/garden-0.13.28-macos-arm64.tar.gz"
+    sha256 "6dc4f5030a6786d22333a5153fdaf0baff7b8464411b59e332e846899a4dad4f"
   else
-    url "https://download.garden.io/core/0.13.27/garden-0.13.27-macos-amd64.tar.gz"
-    sha256 "96f0caf73bac25567b78743b977e200fa6eade20dcfdb92908e2ce07a347783b"
+    url "https://download.garden.io/core/0.13.28/garden-0.13.28-macos-amd64.tar.gz"
+    sha256 "2421d7c6c9814f554ffed396c61fa4f3ba95d689f4ea914cabadad0b3d49eaa1"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.28

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.