### PR TITLE
Bump garden-cli to 0.12.71.

### DIFF
--- a/Formula/garden-cli@0.12.rb
+++ b/Formula/garden-cli@0.12.rb
@@ -1,9 +1,9 @@
 class GardenCliAT012 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
-  url "https://download.garden.io/core/0.12.70/garden-0.12.70-macos-amd64.tar.gz"
-  version "0.12.70"
-  sha256 "adb9c63f21f6601cb42e2bcf3a3b0752ca3df8b7cd34708b3aacf36dc39e3c70"
+  url "https://download.garden.io/core/0.12.71/garden-0.12.71-macos-amd64.tar.gz"
+  version "0.12.71"
+  sha256 "a088d03bae9644114d956a7b79b8bc3630c4e9171d9c853a1325db39ef931e6e"
 
   depends_on "rsync"
 


### PR DESCRIPTION
This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden 0.12.71 should be released to Homebrew.