### PR TITLE
Bump garden-cli to 0.13.31

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.30"
+  version "0.13.31"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.30/garden-0.13.30-macos-arm64.tar.gz"
-    sha256 "c56631f3a4bed6a30a8da0f5104bb40a02bdcb5badb005c5ebac89c3d764afc1"
+    url "https://download.garden.io/core/0.13.31/garden-0.13.31-macos-arm64.tar.gz"
+    sha256 "d84a97af1f4c144869ac250294bcb0266248f2f879b64e05131e607760dbd0ba"
   else
-    url "https://download.garden.io/core/0.13.30/garden-0.13.30-macos-amd64.tar.gz"
-    sha256 "3e36cfa9027d2857c51f8060d9144cf8732d936ca1583c57c4dbdc67618d5103"
+    url "https://download.garden.io/core/0.13.31/garden-0.13.31-macos-amd64.tar.gz"
+    sha256 "e5b1478ac67fba3b18b4799708c215a1f0f6c1ac846e6fc28e43e56e378eb97a"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.31

This PR has been generated by the publish-release workflow after the new release

@stefreak Please review this PR carefully and merge once Garden should be released to Homebrew.