### PR TITLE
Bump garden-cli to 0.13.33

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.32"
+  version "0.13.33"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.32/garden-0.13.32-macos-arm64.tar.gz"
-    sha256 "e49406223184bb09bc77070718475d2cc2ca98974ca3561642e293ebd6d31404"
+    url "https://download.garden.io/core/0.13.33/garden-0.13.33-macos-arm64.tar.gz"
+    sha256 "42d67d86d71e42ba90b046fcb10a61060fe6881c4fd1b2a482bafadf472cb7f5"
   else
-    url "https://download.garden.io/core/0.13.32/garden-0.13.32-macos-amd64.tar.gz"
-    sha256 "491eefe22b2ede3bdd8d8ec654dd4a271cae3a4755cb20236b453de7f3b466a5"
+    url "https://download.garden.io/core/0.13.33/garden-0.13.33-macos-amd64.tar.gz"
+    sha256 "601010d6b9e100f4c3860ab80502d329a3cec85124a31e5fea90cddbb416c7ac"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.33

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.