### PR TITLE
Bump garden-cli to 0.13.35

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.34"
+  version "0.13.35"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.34/garden-0.13.34-macos-arm64.tar.gz"
-    sha256 "e6a20f7e6b2ccd47bf958f3ea8e38617bd5895fa94c606838e1534b13479c594"
+    url "https://download.garden.io/core/0.13.35/garden-0.13.35-macos-arm64.tar.gz"
+    sha256 "02edc0552dfe0d6211305d127dd05b0792e4ddcb11e8f7cdf9864fa66f666b4e"
   else
-    url "https://download.garden.io/core/0.13.34/garden-0.13.34-macos-amd64.tar.gz"
-    sha256 "99015b5d26c63bfa25c81bf2445bcc161d76db440ebbaef7d33f946f195611bb"
+    url "https://download.garden.io/core/0.13.35/garden-0.13.35-macos-amd64.tar.gz"
+    sha256 "ba1def6fb4e2cc92c0b5daa4a5ec91794a8e63c3c2acd1e9ab1417f9ea9693c9"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.35

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.