### PR TITLE
Bump garden-cli to 0.13.36

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.35"
+  version "0.13.36"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.35/garden-0.13.35-macos-arm64.tar.gz"
-    sha256 "02edc0552dfe0d6211305d127dd05b0792e4ddcb11e8f7cdf9864fa66f666b4e"
+    url "https://download.garden.io/core/0.13.36/garden-0.13.36-macos-arm64.tar.gz"
+    sha256 "22f8a7a263f80f5fc33e7830375aa93c5f45c6d8c1aaf90b3ea23c8aa59196a5"
   else
-    url "https://download.garden.io/core/0.13.35/garden-0.13.35-macos-amd64.tar.gz"
-    sha256 "ba1def6fb4e2cc92c0b5daa4a5ec91794a8e63c3c2acd1e9ab1417f9ea9693c9"
+    url "https://download.garden.io/core/0.13.36/garden-0.13.36-macos-amd64.tar.gz"
+    sha256 "c4688111a9aafe1f12868bb9996f0d2be9dc14ab31a9253125067f4052b6e9c0"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.36

This PR has been generated by the publish-release workflow after the new release

@stefreak Please review this PR carefully and merge once Garden should be released to Homebrew.