### PR TITLE
Bump garden-cli to 0.13.42

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.41"
+  version "0.13.42"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.41/garden-0.13.41-macos-arm64.tar.gz"
-    sha256 "413ccbbe3c91285c8f5e4b9700344f0a6ad7cd0f2c3d38cc2e0a030c349432ec"
+    url "https://download.garden.io/core/0.13.42/garden-0.13.42-macos-arm64.tar.gz"
+    sha256 "7d5e920880b1a0665258bccf7d7c220ad54158640f41466741e3caef1ea09d05"
   else
-    url "https://download.garden.io/core/0.13.41/garden-0.13.41-macos-amd64.tar.gz"
-    sha256 "6409838d03e6b9451f8cfe4f4a720451436d0419ccb3e3f249faf25a4c0ad50c"
+    url "https://download.garden.io/core/0.13.42/garden-0.13.42-macos-amd64.tar.gz"
+    sha256 "5dad9710340ee1b5df5a3810ebb09f059883f2bf889657d358fc929034d4c3ab"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.42

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.