### PR TITLE
Bump garden-cli to 0.13.43

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.42"
+  version "0.13.43"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.42/garden-0.13.42-macos-arm64.tar.gz"
-    sha256 "7d5e920880b1a0665258bccf7d7c220ad54158640f41466741e3caef1ea09d05"
+    url "https://download.garden.io/core/0.13.43/garden-0.13.43-macos-arm64.tar.gz"
+    sha256 "d9f7d14867e4276bb9d2f24440f27f676787f706b01d08705affdc9343c134a4"
   else
-    url "https://download.garden.io/core/0.13.42/garden-0.13.42-macos-amd64.tar.gz"
-    sha256 "5dad9710340ee1b5df5a3810ebb09f059883f2bf889657d358fc929034d4c3ab"
+    url "https://download.garden.io/core/0.13.43/garden-0.13.43-macos-amd64.tar.gz"
+    sha256 "b89be6d820e344f4f8a5036428e127cb0a942c7281b23f973219dd2d913e91c6"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.43

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.