### PR TITLE
Bump garden-cli to 0.13.44

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.43"
+  version "0.13.44"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.43/garden-0.13.43-macos-arm64.tar.gz"
-    sha256 "d9f7d14867e4276bb9d2f24440f27f676787f706b01d08705affdc9343c134a4"
+    url "https://download.garden.io/core/0.13.44/garden-0.13.44-macos-arm64.tar.gz"
+    sha256 "770196c88fae1cbb3539b319211c6f3e5d5041520d36133566487b81068e284e"
   else
-    url "https://download.garden.io/core/0.13.43/garden-0.13.43-macos-amd64.tar.gz"
-    sha256 "b89be6d820e344f4f8a5036428e127cb0a942c7281b23f973219dd2d913e91c6"
+    url "https://download.garden.io/core/0.13.44/garden-0.13.44-macos-amd64.tar.gz"
+    sha256 "1cde6a80d712fdda5771cff4c19284ce681734bb0b937a8517ec81bfaeb70ccc"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.44

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.