### PR TITLE
Bump garden-cli to 0.13.45

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.44"
+  version "0.13.45"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.44/garden-0.13.44-macos-arm64.tar.gz"
-    sha256 "770196c88fae1cbb3539b319211c6f3e5d5041520d36133566487b81068e284e"
+    url "https://download.garden.io/core/0.13.45/garden-0.13.45-macos-arm64.tar.gz"
+    sha256 "a92e3b834d8c69c5dfe825b9280952993051110fe31c77941a5b3231376a7d49"
   else
-    url "https://download.garden.io/core/0.13.44/garden-0.13.44-macos-amd64.tar.gz"
-    sha256 "1cde6a80d712fdda5771cff4c19284ce681734bb0b937a8517ec81bfaeb70ccc"
+    url "https://download.garden.io/core/0.13.45/garden-0.13.45-macos-amd64.tar.gz"
+    sha256 "5b92bf216a0756048852a0285d70309c22db3772ab8fa097939e135009502b23"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.45

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.