### PR TITLE
Bump garden-cli to 0.13.46

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.45"
+  version "0.13.46"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.45/garden-0.13.45-macos-arm64.tar.gz"
-    sha256 "a92e3b834d8c69c5dfe825b9280952993051110fe31c77941a5b3231376a7d49"
+    url "https://download.garden.io/core/0.13.46/garden-0.13.46-macos-arm64.tar.gz"
+    sha256 "c207667965eba301dda3837bf619862d4d26e9bbc5ab87c45718d0654e5f4d6e"
   else
-    url "https://download.garden.io/core/0.13.45/garden-0.13.45-macos-amd64.tar.gz"
-    sha256 "5b92bf216a0756048852a0285d70309c22db3772ab8fa097939e135009502b23"
+    url "https://download.garden.io/core/0.13.46/garden-0.13.46-macos-amd64.tar.gz"
+    sha256 "3026f18e04b26828aad99c26234dced06d86633c709684acdbb45f858d1e1b31"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.46

This PR has been generated by the publish-release workflow after the new release

@stefreak Please review this PR carefully and merge once Garden should be released to Homebrew.