### PR TITLE
Bump garden-cli to 0.13.49

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.48"
+  version "0.13.49"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.48/garden-0.13.48-macos-arm64.tar.gz"
-    sha256 "41bc9ac44ac2dbafa0321a66f2684fbd20962745079c91d907beb9de77083128"
+    url "https://download.garden.io/core/0.13.49/garden-0.13.49-macos-arm64.tar.gz"
+    sha256 "085d83f1856b419fcdaa7b673bd46e2cad2051faca9fea7503d1d95ca4bb7c8f"
   else
-    url "https://download.garden.io/core/0.13.48/garden-0.13.48-macos-amd64.tar.gz"
-    sha256 "1e3ca45c04998261f96b3028d9f463ccac03aadf8ae34ed6e8c2b61bbbaa7022"
+    url "https://download.garden.io/core/0.13.49/garden-0.13.49-macos-amd64.tar.gz"
+    sha256 "c033c1d301d4cdfaae6b3a6e42f8d96f5bc69c3751dbe7940ada0420fbd3e532"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.49

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.