### PR TITLE
Bump garden-cli to 0.13.54

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.53"
+  version "0.13.54"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.53/garden-0.13.53-macos-arm64.tar.gz"
-    sha256 "f4c183cc24f4b96b056403a9f9d752b255f553914c0321c347afc2d5951f1378"
+    url "https://download.garden.io/core/0.13.54/garden-0.13.54-macos-arm64.tar.gz"
+    sha256 "a1317910ec5eee9407d3ad20f5ce9aecc9e2c1a005e45448397a450a3b06ae71"
   else
-    url "https://download.garden.io/core/0.13.53/garden-0.13.53-macos-amd64.tar.gz"
-    sha256 "bb42d7f4106884a93b49d0d722fd99d181bebe7c4fa8d9aad7a9d4aa934f5015"
+    url "https://download.garden.io/core/0.13.54/garden-0.13.54-macos-amd64.tar.gz"
+    sha256 "361d234df2a9643ab6065e6139099b96844b9920e08d585dfd4b82282cee8aca"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.54

This PR has been generated by the publish-release workflow after the new release

@stefreak Please review this PR carefully and merge once Garden should be released to Homebrew.