### PR TITLE
Bump garden-cli to 0.14.1

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.57"
+  version "0.14.1"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.57/garden-0.13.57-macos-arm64.tar.gz"
-    sha256 "5678d683fd428394d279dfc753be0a4e32bfa67ac956c7aaf9458e12fb6ca2de"
+    url "https://download.garden.io/core/0.14.1/garden-0.14.1-macos-arm64.tar.gz"
+    sha256 "205d8dd1504df4acb324799417a9d5404595e18853299805a1693211c33fe155"
   else
-    url "https://download.garden.io/core/0.13.57/garden-0.13.57-macos-amd64.tar.gz"
-    sha256 "2c5df758208274e32cd692caa99d68019a62dd9aa6c21740e5162294582bb583"
+    url "https://download.garden.io/core/0.14.1/garden-0.14.1-macos-amd64.tar.gz"
+    sha256 "501c90e232e237bf74dd4eea09d201a95097eab139d274844ba3b0814ed380e1"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.14.1

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.