### PR TITLE
fix: correct class name for 0.13 formula

### DIFF
--- a/Formula/garden-cli@0.13.rb
+++ b/Formula/garden-cli@0.13.rb
@@ -1,4 +1,4 @@
-class GardenCli < Formula
+class GardenCliAT013 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 


### PR DESCRIPTION
A follow-up fix for 0.13 formula.

Fixes #140
Patches #141