### PR TITLE
Bump garden-cli to 0.13.58

### DIFF
--- a/Formula/garden-cli@0.13.rb
+++ b/Formula/garden-cli@0.13.rb
@@ -1,4 +1,4 @@
-class GardenCli < Formula
+class GardenCliAT013 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 

--- a/Formula/garden-cli@0.13.rb
+++ b/Formula/garden-cli@0.13.rb
@@ -1,16 +1,16 @@
-class GardenCliAT013 < Formula
+class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.57"
+  version "0.13.58"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.57/garden-0.13.57-macos-arm64.tar.gz"
-    sha256 "5678d683fd428394d279dfc753be0a4e32bfa67ac956c7aaf9458e12fb6ca2de"
+    url "https://download.garden.io/core/0.13.58/garden-0.13.58-macos-arm64.tar.gz"
+    sha256 "9ee606b4f2ca943f3e294cb673c190d961b20408e96c3a43f6a1e8540df171ef"
   else
-    url "https://download.garden.io/core/0.13.57/garden-0.13.57-macos-amd64.tar.gz"
-    sha256 "2c5df758208274e32cd692caa99d68019a62dd9aa6c21740e5162294582bb583"
+    url "https://download.garden.io/core/0.13.58/garden-0.13.58-macos-amd64.tar.gz"
+    sha256 "dc5fcde30572e60b597483e3ae77ee04af2a84e5dd93cda7e087aa7c5c6d04ad"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.58

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.