### PR TITLE
Bump garden-cli to 0.14.2

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.14.1"
+  version "0.14.2"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.14.1/garden-0.14.1-macos-arm64.tar.gz"
-    sha256 "205d8dd1504df4acb324799417a9d5404595e18853299805a1693211c33fe155"
+    url "https://download.garden.io/core/0.14.2/garden-0.14.2-macos-arm64.tar.gz"
+    sha256 "b059175fb3f73b5bae5aa37ebbc13d040680d2de33c8ef949a1bdc963bdc811b"
   else
-    url "https://download.garden.io/core/0.14.1/garden-0.14.1-macos-amd64.tar.gz"
-    sha256 "501c90e232e237bf74dd4eea09d201a95097eab139d274844ba3b0814ed380e1"
+    url "https://download.garden.io/core/0.14.2/garden-0.14.2-macos-amd64.tar.gz"
+    sha256 "37ffd0dffc82f078badcad065e00af7853dd8c73ee1e78dd7200031684d515dd"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.14.2

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.