### PR TITLE
Bump garden-cli to 0.13.59

### DIFF
--- a/Formula/garden-cli@0.13.rb
+++ b/Formula/garden-cli@0.13.rb
@@ -2,15 +2,15 @@ class GardenCliAT013 < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.13.58"
+  version "0.13.59"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.13.58/garden-0.13.58-macos-arm64.tar.gz"
-    sha256 "9ee606b4f2ca943f3e294cb673c190d961b20408e96c3a43f6a1e8540df171ef"
+    url "https://download.garden.io/core/0.13.59/garden-0.13.59-macos-arm64.tar.gz"
+    sha256 "882718c8ab1039b3771e8a15d4ab44a34ff95ef3b4c40bf1faae52bc195951ba"
   else
-    url "https://download.garden.io/core/0.13.58/garden-0.13.58-macos-amd64.tar.gz"
-    sha256 "dc5fcde30572e60b597483e3ae77ee04af2a84e5dd93cda7e087aa7c5c6d04ad"
+    url "https://download.garden.io/core/0.13.59/garden-0.13.59-macos-amd64.tar.gz"
+    sha256 "515786ec26b9e5ed215331f3b9d5ad7dc4437709c904e564c2301068f647595e"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.13.59

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.