### PR TITLE
Bump garden-cli to 0.14.3

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.14.2"
+  version "0.14.3"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.14.2/garden-0.14.2-macos-arm64.tar.gz"
-    sha256 "b059175fb3f73b5bae5aa37ebbc13d040680d2de33c8ef949a1bdc963bdc811b"
+    url "https://download.garden.io/core/0.14.3/garden-0.14.3-macos-arm64.tar.gz"
+    sha256 "0cc93785823b6cf9fe633681029f7fc567ce8a1344c823b4f331ac1477899b31"
   else
-    url "https://download.garden.io/core/0.14.2/garden-0.14.2-macos-amd64.tar.gz"
-    sha256 "37ffd0dffc82f078badcad065e00af7853dd8c73ee1e78dd7200031684d515dd"
+    url "https://download.garden.io/core/0.14.3/garden-0.14.3-macos-amd64.tar.gz"
+    sha256 "840b5ccbab080383d689e214842e5b91d7f3dc944b1f01ff38b5187409267778"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.14.3

This PR has been generated by the publish-release workflow after the new release

@vvagaytsev Please review this PR carefully and merge once Garden should be released to Homebrew.