### PR TITLE
Bump garden-cli to 0.14.8

### DIFF
--- a/Formula/garden-cli.rb
+++ b/Formula/garden-cli.rb
@@ -2,15 +2,15 @@ class GardenCli < Formula
   desc "Development engine for Kubernetes"
   homepage "https://garden.io"
 
-  version "0.14.7"
+  version "0.14.8"
 
   # Determine architecture
   if Hardware::CPU.arm?
-    url "https://download.garden.io/core/0.14.7/garden-0.14.7-macos-arm64.tar.gz"
-    sha256 "c9b64dee1aa9b02d14f9f1738a47a411507dbd4ca7809fa295b53386404b89d2"
+    url "https://download.garden.io/core/0.14.8/garden-0.14.8-macos-arm64.tar.gz"
+    sha256 "80059eab8f6e184a61467a178c1828c17865dfc053596f8e1b2baff20be5c7fb"
   else
-    url "https://download.garden.io/core/0.14.7/garden-0.14.7-macos-amd64.tar.gz"
-    sha256 "ab1ce6d412895e6ef7a0562c19f61d6a7532899c7a07abd99f8971d883d92506"
+    url "https://download.garden.io/core/0.14.8/garden-0.14.8-macos-amd64.tar.gz"
+    sha256 "93b9d63f2a1da36c2a8f866137f75aca46a6a7b696bc031bc69ccbb3608331e2"
   end
 
   def install


### PR DESCRIPTION
Bump garden-cli.rb to 0.14.8

This PR has been generated by the publish-release workflow after the new release

@edvald-garden Please review this PR carefully and merge once Garden should be released to Homebrew.